### PR TITLE
Fix context not being apart of the struct

### DIFF
--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -6,7 +6,7 @@ defmodule Airbrake.Payload do
     url: Airbrake.Mixfile.project()[:package][:links][:github]
   }
 
-  defstruct apiKey: nil, notifier: @notifier_info, errors: nil
+  defstruct apiKey: nil, context: nil, notifier: @notifier_info, errors: nil
 
   def new(exception, stacktrace, options \\ [])
 


### PR DESCRIPTION
The environment (and host) are missing from airbrake. This is because the json encoding (https://github.com/romul/airbrake-elixir/blob/master/lib/airbrake/worker.ex#L98) looks to be stripping out the :context key which was not in the struct definition.

This change adds the :context key and local testing shows it working now, where the hostname and the environment are being transmitted properly.

Created this as a fork because it looks like the project isn't being maintained. Not sure if we want to keep up with a fork, although I haven't found any alternative libraries. If so, I can work on creating an action to deploy releases to mix.

To-do list for fork (if going forward):

- Make sure the license is being adhered to: https://github.com/romul/airbrake-elixir/blob/master/LICENSE and create a PR to the original project if needed; open source this?
- Remove .travis file
- Add gh action to test and release based on tag (upload to hex)
- cleanup readme
- Update projects to use this
- Look into any deprecation issues and add a 2nd seashell for that